### PR TITLE
turn off caching of options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.js
+yarn.lock

--- a/index.coffee
+++ b/index.coffee
@@ -7,9 +7,15 @@ plaintext_file = null
 encrypted_file = null
 
 main = (options) ->
-  PASSWORD       ?= options.password
-  plaintext_file ?= options.plaintext_file
-  encrypted_file ?= options.encrypted_file || options.plaintext_file + '.yael'
+  cache = options.cache ?= true
+  if cache
+    PASSWORD       ?= options.password
+    plaintext_file ?= options.plaintext_file
+    encrypted_file ?= options.encrypted_file || options.plaintext_file + '.yael'
+  else
+    PASSWORD        = options.password
+    plaintext_file  = options.plaintext_file
+    encrypted_file  = options.encrypted_file || options.plaintext_file + '.yael'
 
   # When no plaintext file exists, load from encrypted file.
   if not fs.existsSync plaintext_file


### PR DESCRIPTION
Add ability to turn off caching options. with current code it remembers password, plaintext and encrypted file options which presents a problem when you want to use more than 1 vault in your code. in my case i read vault and password and encrypted file options are set. I then try write to another file but it writes to the 1st encrypted file as it is already set. allowing the user to turn off caching options fixes this. new cache option defaults to true to mimic current original behaviour for backwards compatibility.

**Help Please!!!**
Firstly thank you for creating this module I have used it a fair bit for local dev. Secondly if you are happy with this PR could push this change to NPM that would be appreciated.
